### PR TITLE
Nd refactor traveler

### DIFF
--- a/src/Traveler.js
+++ b/src/Traveler.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 export default class Traveler {
   constructor({ id, name, travelerType }) {
     this.id = id;
@@ -15,7 +13,7 @@ export default class Traveler {
     tripsData.forEach(trip => {
       if (trip.date < currentDate && trip.status === "approved") {
         this.pastTrips.push(trip);
-      } else if (currentDate >= trip.date && currentDate <= moment(new Date(trip.date)).add(trip.duration, 'd').format('YYYY/MM/DD') && trip.status === "approved") {
+      } else if (currentDate >= trip.date && currentDate <= trip.endDate && trip.status === "approved") {
         this.currentTrips.push(trip);
       } else if (currentDate <= trip.date && trip.status === "approved") {
         this.upcomingTrips.push(trip);

--- a/test/Traveler-test.js
+++ b/test/Traveler-test.js
@@ -6,7 +6,7 @@ import Traveler from '../src/Traveler';
 import Trip from '../src/Trip';
 
 describe.only('Traveler', () => {
-  let traveler, trip, trip1, trip2, trip3, trip4;
+  let traveler, trip, trip1, trip2, trip3, trip4, allTrips;
 
   beforeEach(() => {
     traveler = new Traveler(travelerData[0]);
@@ -54,23 +54,23 @@ describe.only('Traveler', () => {
   
   describe('Traveler sortTripsByStatus Method', () => {
     it('Sort a travelers destination trip data into past trips for past trips that have ended', () => {
-      traveler.sortTripsByStatus("2019/09/18", tripsData);
-      expect(traveler.pastTrips[0]).to.deep.eq(tripsData[3]);
+      traveler.sortTripsByStatus("2019/09/18", allTrips);
+      expect(traveler.pastTrips[0]).to.deep.eq(allTrips[3]);
     });
   
     it('Sort a travelers destination trip data into current trips for current trips they are on', () => {
-      traveler.sortTripsByStatus("2019/09/18", tripsData);
-      expect(traveler.currentTrips[0]).to.deep.eq(tripsData[2]);
+      traveler.sortTripsByStatus("2019/09/18", allTrips);
+      expect(traveler.currentTrips[0]).to.deep.eq(allTrips[2]);
     });
   
     it('Sort a travelers destination trip data into upcoming trips for current trips that have been approved', () => {
-      traveler.sortTripsByStatus("2019/09/18", tripsData);
-      expect(traveler.upcomingTrips[0]).to.deep.eq(tripsData[0]);
+      traveler.sortTripsByStatus("2019/09/18", allTrips);
+      expect(traveler.upcomingTrips[0]).to.deep.eq(allTrips[0]);
     });
   
     it('Sort a travelers destination trip data into pending trips for current trips that have not been approved', () => {
-      traveler.sortTripsByStatus("2019/09/18", tripsData);
-      expect(traveler.pendingTrips[0]).to.deep.eq(tripsData[1]);
+      traveler.sortTripsByStatus("2019/09/18", allTrips);
+      expect(traveler.pendingTrips[0]).to.deep.eq(allTrips[1]);
     });
   });
 });

--- a/test/Traveler-test.js
+++ b/test/Traveler-test.js
@@ -3,12 +3,19 @@ const { expect } = require("chai");
 import travelerData from './test-data/traveler-test-data';
 import tripsData from './test-data/trips-test-data';
 import Traveler from '../src/Traveler';
+import Trip from '../src/Trip';
 
-describe('Traveler', () => {
-  let traveler;
+describe.only('Traveler', () => {
+  let traveler, trip, trip1, trip2, trip3, trip4;
 
   beforeEach(() => {
     traveler = new Traveler(travelerData[0]);
+    trip = new Trip(tripsData[0]);
+    trip1 = new Trip(tripsData[1]);
+    trip2 = new Trip(tripsData[2]);
+    trip3 = new Trip(tripsData[3]);
+    trip4 = new Trip(tripsData[4]);
+    allTrips = [trip, trip1, trip2, trip3, trip4];
   });
 
   describe('Traveler Properties', () => {


### PR DESCRIPTION
### What’s this PR do?  
- Refactors the Traveler class to use instantiations of the Trip class as opposed to raw trip data from API.
- Utilizes the Trip class endDate property when sorting a user's trip data.
- Remove moment.js from Traveler class as it is no longer needed with the Trip class having the endDate property.
 
### Where should the reviewer start?  
- Git pull this branch.
- Open Traveler.js and Traveler-test.js.
 
### How should this be manually tested?  
- Run `npm install` if mocha/chai not installed.
- Run `npm test` to assert against testing suite.
- Check for JS flow and implementation.
 
### Any background context you want to provide?  
- Will have to refactor the Trip class as I had to ensure that it kept the status from previous trip data instead of setting all status defaults to pending.
- Changed the Trip class to accept an object as opposed to raw data as that is how it will come in the API. Will start the refactor branch for Trip next PR.
 
### What are the relevant tickets?  
- Closes #58 
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A