### PR TITLE
Nd header refactor

### DIFF
--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -3,10 +3,11 @@ header {
   align-items: center;
   width: 100%;
   height: auto;
+  font-family: $monserrat-font;
 
   .header-logo {
     max-width: 100px;
-    margin-right: 40px;
+    margin-right: 20px;
 
     img {
       width: 100%;
@@ -20,7 +21,21 @@ header {
   }
 
   .header-links > a {
-    margin: 10px 20px;
+    color: $blue-text-color;
+    margin: 10px;
+    border-bottom: 1px solid transparent;
+    text-decoration: none;
+    transition: all 0.2s ease;
+
+    &:hover {
+      color: $orange-text-color;
+      border-bottom: 1px solid $orange-text-color;
+      cursor: pointer;
+    }
+
+    @media screen and (max-width: 935px) {
+      @include displayFlexWithPaddingAndMargin(0, 0, column);
+    }
   }
 
   .header-ytd {

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -33,7 +33,7 @@ header {
       cursor: pointer;
     }
 
-    @media screen and (max-width: 935px) {
+    @media screen and (max-width: 800px) {
       @include displayFlexWithPaddingAndMargin(0, 0, column);
     }
   }
@@ -41,5 +41,6 @@ header {
   .header-ytd {
     margin-left: auto;
     margin-right: 2%;
+    text-align: center;
   }
 }

--- a/src/css/_variables.scss
+++ b/src/css/_variables.scss
@@ -1,0 +1,3 @@
+$monserrat-font: 'Montserrat', sans-serif;
+$orange-text-color: #f2632b;
+$blue-text-color: #2b3d91;

--- a/src/domUpdates/domUpdates.js
+++ b/src/domUpdates/domUpdates.js
@@ -16,6 +16,7 @@ const domUpdates = {
     this.sortTravelerTrips();
     this.populateDestinationsOnDOM();
     this.displayAllTravelerTrips('upcoming');
+    this.displayTravelerYTDTotal();
   },
 
   displayCurrentTraveler() {
@@ -64,6 +65,12 @@ const domUpdates = {
         </section>
       </article>
     `;
+  },
+
+  displayTravelerYTDTotal() {
+    const domTripYTDTitle = document.querySelector('.header-ytd-text');
+    const yearlyYTDTotal = this.currentTraveler.getYTDTotal('2020', this.allTripsData, this.allDestinationData);
+    domTripYTDTitle.innerText = `You have spent $${yearlyYTDTotal} this year`
   }
 }
 

--- a/src/domUpdates/domUpdates.js
+++ b/src/domUpdates/domUpdates.js
@@ -70,7 +70,7 @@ const domUpdates = {
   displayTravelerYTDTotal() {
     const domTripYTDTitle = document.querySelector('.header-ytd-text');
     const yearlyYTDTotal = this.currentTraveler.getYTDTotal('2020', this.allTripsData, this.allDestinationData);
-    domTripYTDTitle.innerText = `You have spent $${yearlyYTDTotal} this year`
+    domTripYTDTitle.innerHTML = `2020 YTD Total<br>$${yearlyYTDTotal}`;
   }
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@
         <a href="#">Pending Trips</a>
       </section>
       <section class="header-ytd">
-        <p class="header-ytd-text">You have spent $15000 this year</p>
+        <p class="header-ytd-text"></p>
       </section>
     </header>
     <main>

--- a/src/index.html
+++ b/src/index.html
@@ -4,15 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" type="image/jpg" href="./images/travel-tracker-logo.png"/>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,500&display=swap" rel="stylesheet">
     <title>Travel Tracker</title>
   </head>
   <body>
     <header>
       <section class="header-logo">
         <img src="./images/travel-tracker-logo.png" alt="Travel Tracker">
-      </section>
-      <section class="header-title">
-        <h1>Travel Tracker</h1>
       </section>
       <section class="header-links">
         <a href="#">Past Trips</a>


### PR DESCRIPTION
### What’s this PR do?  
- This PR Refactors the header. Adding in links to transition between different views and display a user's past, current, upcoming and pending trips.
- Displays a user's total YTD cost on the screen within the header. It only factors in approved trips and not pending trips.
- The header is mobile friendly down to 350px.
- Added a font-family for the header to see how it would look with design idea.
- Added hover states to links at the top.
 
### Where should the reviewer start?  
- Git pull this branch.
- Open files index.html, index.js, domUpdates.js and _header.scss files.
 
### How should this be manually tested?  
- Run `npm start` to open server.
- Navigate to localhost:8080.
- Open dev tools mobile viewer and test on different views.
 
### Any background context you want to provide?  
- N/A
 
### What are the relevant tickets?  
- Closes #46 
- Closes #9
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A