### PR TITLE
Nd traveler class ytd method

### DIFF
--- a/src/Traveler.js
+++ b/src/Traveler.js
@@ -28,4 +28,22 @@ export default class Traveler {
       }
     })
   }
+
+  getYTDTotal(currentYear, tripsData, destinationData) {
+    const getAllUserTripsThisYear = tripsData.filter(trip => {
+      return this.id === trip.userID && trip.date.includes(currentYear) && trip.status === 'approved';
+    });
+    const getYearlyTotal = getAllUserTripsThisYear.reduce((total, trip) => {
+      destinationData.forEach(destination => {
+        if (trip.destinationID === destination.id) {
+          let tripFlightCost = destination.estimatedFlightCostPerPerson * trip.travelers;
+          let tripLodgingCost = destination.estimatedLodgingCostPerDay * trip.duration * trip.travelers;
+          let travelAgentFee = (tripFlightCost + tripLodgingCost) * .1;
+          total += tripFlightCost + tripLodgingCost + travelAgentFee;
+        }
+      });
+      return total;
+    }, 0);
+    return getYearlyTotal.toFixed(2);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import moment from 'moment';
 let currentTraveler, todaysDate;
 let allTripsData = [];
 let allDestinationsData = [];
+
 const submitNewTripBtn = document.querySelector('#btnSubmit');
 
 const getAllInfoOnLogin = () => {

--- a/test/Traveler-test.js
+++ b/test/Traveler-test.js
@@ -1,12 +1,14 @@
 const { expect } = require("chai");
 
+import destinationData from './test-data/destination-test-data';
 import travelerData from './test-data/traveler-test-data';
 import tripsData from './test-data/trips-test-data';
+import Destination from '../src/Destination';
 import Traveler from '../src/Traveler';
 import Trip from '../src/Trip';
 
 describe('Traveler', () => {
-  let traveler, trip, trip1, trip2, trip3, trip4, allTrips;
+  let traveler, trip, trip1, trip2, trip3, trip4, trip5, allTrips, allDestinations;
 
   beforeEach(() => {
     traveler = new Traveler(travelerData[0]);
@@ -15,7 +17,13 @@ describe('Traveler', () => {
     trip2 = new Trip(tripsData[2]);
     trip3 = new Trip(tripsData[3]);
     trip4 = new Trip(tripsData[4]);
-    allTrips = [trip, trip1, trip2, trip3, trip4];
+    trip5 = new Trip(tripsData[5]);
+    allTrips = [trip, trip1, trip2, trip3, trip4, trip5];
+    allDestinations = [];
+    destinationData.forEach(destination => {
+      let newDestination = new Destination(destination);
+      allDestinations.push(newDestination);
+    })
   });
 
   describe('Traveler Properties', () => {
@@ -65,12 +73,18 @@ describe('Traveler', () => {
   
     it('Sort a travelers destination trip data into upcoming trips for current trips that have been approved', () => {
       traveler.sortTripsByStatus("2019/09/18", allTrips);
-      expect(traveler.upcomingTrips[0]).to.deep.eq(allTrips[0]);
+      expect(traveler.upcomingTrips[0]).to.deep.eq(allTrips[0, 5]);
     });
   
     it('Sort a travelers destination trip data into pending trips for current trips that have not been approved', () => {
       traveler.sortTripsByStatus("2019/09/18", allTrips);
       expect(traveler.pendingTrips[0]).to.deep.eq(allTrips[1]);
+    });
+  });
+
+  describe('Traveler getYTDTotal', () => {
+    it('Should show how much a user has spent for the entire year, not including pending trips', () => {
+      expect(traveler.getYTDTotal('2020', allTrips, allDestinations)).to.eq('12595.00');
     });
   });
 });

--- a/test/test-data/destination-test-data.js
+++ b/test/test-data/destination-test-data.js
@@ -46,6 +46,14 @@ const destinationData = [
     estimatedFlightCostPerPerson:	900,
     image:	"https://images.unsplash.com/photo-1580237541049-2d715a09486e?,ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2090&,q=80",
     alt:	"white and brown concrete buildings near sea under white clouds during daytime"
+  },
+  {
+    id: 6,
+    destination:	"Colombo, Sri Lanka",
+    estimatedLodgingCostPerDay:	55,
+    estimatedFlightCostPerPerson:	1300,
+    image:	"https://images.unsplash.com/,photo-1578159802020-13ec49d669df?ixlib=rb-1.2.1&,ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1950&q=80",
+    alt:	"people walking inside flea market"
   }
 ]
 

--- a/test/test-data/trips-test-data.js
+++ b/test/test-data/trips-test-data.js
@@ -48,6 +48,16 @@ const trips = [
     duration:	11,
     status:	"approved",
     suggestedActivities:	[]
+  },
+  {
+    id:	2,
+    userID:	1,
+    destinationID:	6,
+    travelers:	5,
+    date:	"2020/10/04",
+    duration:	18,
+    status:	"approved",
+    suggestedActivities:	[]
   }
 ]
 


### PR DESCRIPTION
### What’s this PR do?  
- This PR has the `getYTDTotal` for the traveler class.
- On login, it will show a user's total spent for a year, not including pending approvals.
- Altered some test files to get the right data for a test to pass.
 
### Where should the reviewer start?  
- Git pull this branch.
- Open Traveler.js, domUpdates.js, index.html, can optionally open any of the files in the test-data folder.
 
### How should this be manually tested?  
- Run `npm test` inside terminal to assert against the testing suite.
- Run `npm start` to open local server.
- Navigate to localhost:8080.
- Refresh the page multiple times and calculate the math in the top right hand corner of the header.
- This math includes a 10% agent fee charge as well.
 
### Any background context you want to provide?  
- The math has been cross checked with multiple other cohort members. Everything should be calculating and displaying as intended.
- All charges includes a 10% agent fee charge as well.
 
### What are the relevant tickets?  
- Closes #79 
- Closes #78 
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A